### PR TITLE
Add Themis-style issue templates with source attribution

### DIFF
--- a/.github/ISSUE_TEMPLATE/Documentation template
+++ b/.github/ISSUE_TEMPLATE/Documentation template
@@ -1,0 +1,56 @@
+# Themis-style convention proposal (ImageWG)
+
+(Adapted from Themis template: https://github.com/OHDSI/Themis/tree/master/.github/ISSUE_TEMPLATE )
+
+**PLEASE COPY THIS TEMPLATE INTO ASSIGNED ISSUE**
+**Note: if no information available, put in 'NA'.**
+
+## Issue # and location
+For this ratified convention, the issue number given when the issue was created by GitHub. Was this a CDM issue, Themis issue, found in CDM documentation or found on the forum?
+
+Format as follows:
+- [Themis issue #57](https://github.com/OHDSI/Themis/issues/57)
+- [CDM issue #156](https://github.com/OHDSI/CommonDataModel/issues/156)
+
+## Issue summary
+Be specific
+
+## Convention type
+Global or Table
+
+## CDM table
+Name of CDM table affected by the convention. If global convention, then NA
+
+## CDM field
+Name of CDM field affected by the global. If global issue, then NA
+
+## Links to issue discussion
+Links to location of discussion on forums, CDM GitHub, Themis GitHub, etc.
+
+Format as follows:
+- [OHDSI Forums discussion](https://forums.ohdsi.org/t/drug-exposure-quantity-recalculation/9607)
+- [CDM Documentation](https://ohdsi.github.io/CommonDataModel/cdm54.html#drug_exposure)
+
+## Provenance of data
+What is the type of data to which the convention applies? General/all, EHR (hospital or GP), claims, country of origin, etc. Please be as specific as possible.
+
+## The ratified convention
+Conceptual, english description of the ratified convention including table and field. Example use cases, data flow diagrams, or other visiuals are encouraged, if applicable.
+
+## Date of ratification/published
+Some previously ratified conventions might not contain this data. If unable to find a date, then use the current date as the date of publication in the Themis repository.
+
+## Downstream implications
+Does the OHDSI community need to update OHDSI tools or methods based on the publication of this convention? If yes, which tools or methods?
+
+## Link to DQD check
+Is this a DQD check? Make your best guess based on the descriptions available on  https://ohdsi.github.io/DataQualityDashboard/articles/checkIndex.html. Do not spend more than 5 minutes on this activity.
+
+Format as follows:
+Yes - [isRequired](https://ohdsi.github.io/DataQualityDashboard/articles/checks/isRequired.html).
+
+## Related conventions/further information
+Other helpful information, if needed. i.e. related conventions, queries to evaluate source or CDM data, or any additional information
+
+**#Tags**
+Any words, phrases that allow users to more easily find this convention in the library.

--- a/.github/ISSUE_TEMPLATE/themis-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/themis-issue-template.md
@@ -1,0 +1,24 @@
+---
+name: Themis issue template
+about: 'Use this template to fill in all attributes of an issue '
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Themis-style convention proposal (ImageWG)
+
+(Adapted from Themis template: https://github.com/OHDSI/Themis/tree/master/.github/ISSUE_TEMPLATE )
+
+**Issue Name:** Be clear and concise. If it is an issue with a CDM table or field, then make sure the table name & field are part of the issue name. If it is an issue with source data, then the source data domain should be part of the issue name.
+
+**Issue Type:** Usually the issue type is one of the following: Lack of an ETL convention for a CDM table and/or field, multiple standard concept_ids for an idea of interest, multiple ways to store source data in the OMOP CDM to represent an idea of interest.
+
+**Description:** Link to section of documentation which lacks or has unclear descriptions, description of idea of interest and the multiple standard concept_ids to represent this idea, or description of idea of interest and the different ways these data can be ETL’d into the CDM with standard concept_ids.
+
+**Related forum post:** If there is an OHDSI forum post related to this topic, please post all relevant links here.
+
+**Suggested solution:** If you have a suggested solution or convention for these data, add it here.
+
+**Reported By:** Your name


### PR DESCRIPTION
Import Themis issue template files into ImageWG and add explicit source attribution text so the adapted origin is documented in-repo.